### PR TITLE
docs: link to experimental v2 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ Included components and all other information can be found in our [wiki].
 
 [npm-badge]: https://img.shields.io/npm/v/@stencil/router.svg
 [npm-badge-url]: https://www.npmjs.com/package/@stencil/router
+
+---
+
+**Stencil Router 2.0** 🆕
+
+There is a new experimental version of Stencil Router located in the [`v2` branch](https://github.com/ionic-team/stencil-router/tree/v2).
+
+- **Lightweight** (600bytes)
+- **Treeshakable** (not used features are not included in the final build)
+- **Simple**, provide the bare mininum but it make it extendable with hooks.
+- **No DOM**: Router is not render any extra DOM element, to keep styling simple.
+- **Fast**: As fast and lightweight as writing your own router with if statements.
+
+Details can be found [in the README](https://github.com/ionic-team/stencil-router/tree/v2#readme).


### PR DESCRIPTION
This PR adds a plug to the experimental v2 router.

The future version of Stencil Router is ambiguous and hard to find unless you know where to look. Most people in the community seem to link to Manu's repo: https://github.com/ionic-team/stencil-router-v2

Hopefully this will get more eyes and feedback on v2.