### PR TITLE
fix: allow `scrollTopOffset` to be `0`

### DIFF
--- a/packages/router/src/components/switch/switch.tsx
+++ b/packages/router/src/components/switch/switch.tsx
@@ -84,7 +84,7 @@ export class RouteSwitch implements ComponentInterface {
     // Set all props on the new active route then wait until it says that it
     // is completed
     const activeChild = this.subscribers[this.activeIndex];
-    if (this.scrollTopOffset) {
+    if (this.scrollTopOffset != null) {
       activeChild.el.scrollTopOffset = this.scrollTopOffset;
     }
     activeChild.el.group = this.group;


### PR DESCRIPTION
fixes #104 

With this change, if expression evaluates to false for `null` and `undefined` but true for `0` so setting `scrollTopOffset` to `0` should work (again).