### PR TITLE
chore(ownership): update demo to use community package

### DIFF
--- a/packages/demo/package-lock.json
+++ b/packages/demo/package-lock.json
@@ -1,1470 +1,451 @@
 {
   "name": "@stencil/starter",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@stencil/router": {
-      "version": "0.2.7-1",
+  "packages": {
+    "": {
+      "name": "@stencil/starter",
+      "version": "0.0.1",
       "dependencies": {
-        "@samverschueren/stream-to-observable": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "any-observable": "^0.3.0"
-          }
-        },
-        "@stencil/state-tunnel": {
-          "version": "0.0.9-1",
-          "bundled": true
-        },
-        "ansi-align": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^2.0.0"
-          }
-        },
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "bundled": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "any-observable": {
-          "version": "0.3.0",
-          "bundled": true
-        },
-        "array-find-index": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "array-union": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "array-uniq": "^1.0.1"
-          }
-        },
-        "array-uniq": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "boxen": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "bundled": true
-        },
-        "camelcase-keys": {
-          "version": "4.2.0",
-          "bundled": true,
-          "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
-          }
-        },
-        "capture-stack-trace": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "chardet": {
-          "version": "0.4.2",
-          "bundled": true
-        },
-        "ci-info": {
-          "version": "1.4.0",
-          "bundled": true
-        },
-        "cli-boxes": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "restore-cursor": "^2.0.0"
-          }
-        },
-        "cli-truncate": {
-          "version": "0.2.1",
-          "bundled": true,
-          "requires": {
-            "slice-ansi": "0.0.4",
-            "string-width": "^1.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            }
-          }
-        },
-        "cli-width": {
-          "version": "2.2.0",
-          "bundled": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "bundled": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "configstore": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "dot-prop": "^4.1.0",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "create-error-class": {
-          "version": "3.0.2",
-          "bundled": true,
-          "requires": {
-            "capture-stack-trace": "^1.0.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "bundled": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "crypto-random-string": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "currently-unhandled": {
-          "version": "0.4.1",
-          "bundled": true,
-          "requires": {
-            "array-find-index": "^1.0.1"
-          }
-        },
-        "date-fns": {
-          "version": "1.29.0",
-          "bundled": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "decamelize-keys": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "decamelize": "^1.1.0",
-            "map-obj": "^1.0.0"
-          },
-          "dependencies": {
-            "map-obj": {
-              "version": "1.0.1",
-              "bundled": true
-            }
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true
-        },
-        "del": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "globby": "^6.1.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "p-map": "^1.1.1",
-            "pify": "^3.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
-        "dot-prop": {
-          "version": "4.2.0",
-          "bundled": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "duplexer3": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "elegant-spinner": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "error-ex": {
-          "version": "1.3.2",
-          "bundled": true,
-          "requires": {
-            "is-arrayish": "^0.2.1"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "execa": {
-          "version": "0.10.0",
-          "bundled": true,
-          "requires": {
-            "cross-spawn": "^6.0.0",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
-          }
-        },
-        "exit-hook": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "external-editor": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "chardet": "^0.4.0",
-            "iconv-lite": "^0.4.17",
-            "tmp": "^0.0.33"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "escape-string-regexp": "^1.0.5"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "github-url-from-git": {
-          "version": "1.5.0",
-          "bundled": true
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "global-dirs": {
-          "version": "0.1.1",
-          "bundled": true,
-          "requires": {
-            "ini": "^1.3.4"
-          }
-        },
-        "globby": {
-          "version": "6.1.0",
-          "bundled": true,
-          "requires": {
-            "array-union": "^1.0.1",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "2.3.0",
-              "bundled": true
-            }
-          }
-        },
-        "got": {
-          "version": "6.7.1",
-          "bundled": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            }
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "has-yarn": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "hosted-git-info": {
-          "version": "2.7.1",
-          "bundled": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "import-lazy": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true
-        },
-        "inquirer": {
-          "version": "5.2.0",
-          "bundled": true,
-          "requires": {
-            "ansi-escapes": "^3.0.0",
-            "chalk": "^2.0.0",
-            "cli-cursor": "^2.1.0",
-            "cli-width": "^2.0.0",
-            "external-editor": "^2.1.0",
-            "figures": "^2.0.0",
-            "lodash": "^4.3.0",
-            "mute-stream": "0.0.7",
-            "run-async": "^2.2.0",
-            "rxjs": "^5.5.2",
-            "string-width": "^2.1.0",
-            "strip-ansi": "^4.0.0",
-            "through": "^2.3.6"
-          },
-          "dependencies": {
-            "rxjs": {
-              "version": "5.5.12",
-              "bundled": true,
-              "requires": {
-                "symbol-observable": "1.0.1"
-              }
-            }
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "^1.0.0"
-          }
-        },
-        "is-ci": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "ci-info": "^1.3.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "is-installed-globally": {
-          "version": "0.1.0",
-          "bundled": true,
-          "requires": {
-            "global-dirs": "^0.1.0",
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-npm": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "is-observable": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "symbol-observable": "^1.1.0"
-          },
-          "dependencies": {
-            "symbol-observable": {
-              "version": "1.2.0",
-              "bundled": true
-            }
-          }
-        },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "is-path-inside": "^1.0.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "path-is-inside": "^1.0.1"
-          }
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-promise": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "is-redirect": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-retry-allowed": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "issue-regex": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "json-parse-better-errors": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "package-json": "^4.0.0"
-          }
-        },
-        "listr": {
-          "version": "0.14.2",
-          "bundled": true,
-          "requires": {
-            "@samverschueren/stream-to-observable": "^0.3.0",
-            "is-observable": "^1.1.0",
-            "is-promise": "^2.1.0",
-            "is-stream": "^1.1.0",
-            "listr-silent-renderer": "^1.1.1",
-            "listr-update-renderer": "^0.4.0",
-            "listr-verbose-renderer": "^0.4.0",
-            "p-map": "^1.1.1",
-            "rxjs": "^6.1.0"
-          }
-        },
-        "listr-input": {
-          "version": "0.1.3",
-          "bundled": true,
-          "requires": {
-            "inquirer": "^3.3.0",
-            "rxjs": "^5.5.2",
-            "through": "^2.3.8"
-          },
-          "dependencies": {
-            "inquirer": {
-              "version": "3.3.0",
-              "bundled": true,
-              "requires": {
-                "ansi-escapes": "^3.0.0",
-                "chalk": "^2.0.0",
-                "cli-cursor": "^2.1.0",
-                "cli-width": "^2.0.0",
-                "external-editor": "^2.0.4",
-                "figures": "^2.0.0",
-                "lodash": "^4.3.0",
-                "mute-stream": "0.0.7",
-                "run-async": "^2.2.0",
-                "rx-lite": "^4.0.8",
-                "rx-lite-aggregates": "^4.0.8",
-                "string-width": "^2.1.0",
-                "strip-ansi": "^4.0.0",
-                "through": "^2.3.6"
-              }
-            },
-            "rxjs": {
-              "version": "5.5.12",
-              "bundled": true,
-              "requires": {
-                "symbol-observable": "1.0.1"
-              }
-            }
-          }
-        },
-        "listr-silent-renderer": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "listr-update-renderer": {
-          "version": "0.4.0",
-          "bundled": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "cli-truncate": "^0.2.1",
-            "elegant-spinner": "^1.0.1",
-            "figures": "^1.7.0",
-            "indent-string": "^3.0.0",
-            "log-symbols": "^1.0.2",
-            "log-update": "^1.0.2",
-            "strip-ansi": "^3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "figures": {
-              "version": "1.7.0",
-              "bundled": true,
-              "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
-              }
-            },
-            "log-symbols": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "chalk": "^1.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "listr-verbose-renderer": {
-          "version": "0.4.1",
-          "bundled": true,
-          "requires": {
-            "chalk": "^1.1.3",
-            "cli-cursor": "^1.0.2",
-            "date-fns": "^1.27.2",
-            "figures": "^1.7.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
-              }
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "restore-cursor": "^1.0.1"
-              }
-            },
-            "figures": {
-              "version": "1.7.0",
-              "bundled": true,
-              "requires": {
-                "escape-string-regexp": "^1.0.5",
-                "object-assign": "^4.1.0"
-              }
-            },
-            "onetime": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "restore-cursor": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "exit-hook": "^1.0.0",
-                "onetime": "^1.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "bundled": true
-        },
-        "log-symbols": {
-          "version": "2.2.0",
-          "bundled": true,
-          "requires": {
-            "chalk": "^2.0.1"
-          }
-        },
-        "log-update": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "ansi-escapes": "^1.0.0",
-            "cli-cursor": "^1.0.2"
-          },
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.4.0",
-              "bundled": true
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "restore-cursor": "^1.0.1"
-              }
-            },
-            "onetime": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "restore-cursor": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "exit-hook": "^1.0.0",
-                "onetime": "^1.0.0"
-              }
-            }
-          }
-        },
-        "loud-rejection": {
-          "version": "1.6.0",
-          "bundled": true,
-          "requires": {
-            "currently-unhandled": "^0.4.1",
-            "signal-exit": "^3.0.0"
-          }
-        },
-        "lowercase-keys": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "bundled": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "meow": {
-          "version": "5.0.0",
-          "bundled": true,
-          "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0",
-            "yargs-parser": "^10.0.0"
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "minimist-options": {
-          "version": "3.0.2",
-          "bundled": true,
-          "requires": {
-            "arrify": "^1.0.1",
-            "is-plain-obj": "^1.1.0"
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "bundled": true
-        },
-        "nice-try": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "np": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "@samverschueren/stream-to-observable": "^0.3.0",
-            "any-observable": "^0.3.0",
-            "chalk": "^2.3.0",
-            "del": "^3.0.0",
-            "execa": "^0.10.0",
-            "github-url-from-git": "^1.5.0",
-            "has-yarn": "^1.0.0",
-            "inquirer": "^5.2.0",
-            "issue-regex": "^2.0.0",
-            "listr": "^0.14.1",
-            "listr-input": "^0.1.1",
-            "log-symbols": "^2.1.0",
-            "meow": "^5.0.0",
-            "p-timeout": "^2.0.1",
-            "read-pkg-up": "^3.0.0",
-            "rxjs": "^6.2.0",
-            "semver": "^5.2.0",
-            "split": "^1.0.0",
-            "terminal-link": "^1.1.0",
-            "update-notifier": "^2.1.0"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "path-key": "^2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "mimic-fn": "^1.0.0"
-          }
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "bundled": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-map": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "p-timeout": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "p-finally": "^1.0.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "bundled": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "pify": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "quick-lru": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^3.0.0"
-          }
-        },
-        "redent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
-          }
-        },
-        "registry-auth-token": {
-          "version": "3.3.2",
-          "bundled": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "onetime": "^2.0.0",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "requires": {
-            "glob": "^7.0.5"
-          }
-        },
-        "run-async": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "is-promise": "^2.1.0"
-          }
-        },
-        "rx-lite": {
-          "version": "4.0.8",
-          "bundled": true
-        },
-        "rx-lite-aggregates": {
-          "version": "4.0.8",
-          "bundled": true,
-          "requires": {
-            "rx-lite": "*"
-          }
-        },
-        "rxjs": {
-          "version": "6.3.0",
-          "bundled": true,
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "semver": {
-          "version": "5.5.1",
-          "bundled": true
-        },
-        "semver-diff": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "semver": "^5.0.3"
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "shebang-regex": "^1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true
-        },
-        "slice-ansi": {
-          "version": "0.0.4",
-          "bundled": true
-        },
-        "spdx-correct": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "split": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "through": "2"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "strip-indent": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        },
-        "supports-hyperlinks": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "has-flag": "^2.0.0",
-            "supports-color": "^5.0.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "symbol-observable": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "term-size": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "execa": "^0.7.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
-              }
-            },
-            "execa": {
-              "version": "0.7.0",
-              "bundled": true,
-              "requires": {
-                "cross-spawn": "^5.0.1",
-                "get-stream": "^3.0.0",
-                "is-stream": "^1.1.0",
-                "npm-run-path": "^2.0.0",
-                "p-finally": "^1.0.0",
-                "signal-exit": "^3.0.0",
-                "strip-eof": "^1.0.0"
-              }
-            }
-          }
-        },
-        "terminal-link": {
-          "version": "1.1.0",
-          "bundled": true,
-          "requires": {
-            "ansi-escapes": "^3.1.0",
-            "supports-hyperlinks": "^1.0.1"
-          }
-        },
-        "through": {
-          "version": "2.3.8",
-          "bundled": true
-        },
-        "timed-out": {
-          "version": "4.0.1",
-          "bundled": true
-        },
-        "tmp": {
-          "version": "0.0.33",
-          "bundled": true,
-          "requires": {
-            "os-tmpdir": "~1.0.2"
-          }
-        },
-        "trim-newlines": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "bundled": true
-        },
-        "unique-string": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "crypto-random-string": "^1.0.0"
-          }
-        },
-        "unzip-response": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "update-notifier": {
-          "version": "2.5.0",
-          "bundled": true,
-          "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
-            "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        },
-        "widest-line": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "string-width": "^2.1.1"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "write-file-atomic": {
-          "version": "2.3.0",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
-        },
-        "xdg-basedir": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true
-        },
-        "yargs-parser": {
-          "version": "10.1.0",
-          "bundled": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
-        }
+        "@stencil-community/router": "^1.0.2"
+      },
+      "devDependencies": {
+        "workbox-build": "3.4.1"
       }
+    },
+    "node_modules/@stencil-community/router": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stencil-community/router/-/router-1.0.2.tgz",
+      "integrity": "sha512-GQkhcwDZdkX6k6rE/ZqrH2mbxGt9wPq0KGAdwPJOcZJbfq9cKaSMOuS7heDEBcWgXgxJS2rKqwUKyKTj41g9pA==",
+      "dependencies": {
+        "@stencil/state-tunnel": "^1.0.1"
+      }
+    },
+    "node_modules/@stencil/state-tunnel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
+      "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/common-tags": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
+      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "node_modules/core-js": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true
+    },
+    "node_modules/fs-extra": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+      "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "node_modules/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/hoek": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "node_modules/isemail": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.3.tgz",
+      "integrity": "sha512-5xbsG5wYADIcB+mfLsd+nst1V/D+I7EU7LEZPo2GOIMu4JzfcRs5yQoypP4avA7QtUqgxYLKBYNv4IdzBmbhdw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/joi": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-11.4.0.tgz",
+      "integrity": "sha512-O7Uw+w/zEWgbL6OcHbyACKSj0PkQeUgmehdoXVSxt92QFCq4+1390Rwh5moI2K/OgC7D8RHRZqHZxT2husMJHA==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dev": true,
+      "dependencies": {
+        "hoek": "4.x.x",
+        "isemail": "3.x.x",
+        "topo": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "node_modules/lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "dev": true,
+      "dependencies": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "node_modules/lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "dev": true,
+      "dependencies": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pretty-bytes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",
+      "integrity": "sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "node_modules/topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "dev": true,
+      "dependencies": {
+        "hoek": "4.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/workbox-background-sync": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-3.5.0.tgz",
+      "integrity": "sha512-cioa4pQswVZqoBqVe/h75gZTzoPQHSjDDMjN4QOIyKJgx+oan3EhoOebY1X9/7XBHpkYdDNC7J7F4CZzrnu2dg==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-broadcast-cache-update": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.5.0.tgz",
+      "integrity": "sha512-o1aCtORdKqICjrWVvDg84C4v3yV6gW4VS0axmqMceQJACS0f8idX+AaDd23ZqIEGltpcBe0yOXuc2FLUlNk4gg==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-build": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-3.4.1.tgz",
+      "integrity": "sha512-Qi04XdHjkXbRN0CV5XO1oqDWbJSIm7VYhxmxjtnVcKK8PrMT6rOUFUi9ziDI+8UQgcXbLK4ZChWf2ptZS1/MbA==",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "common-tags": "^1.4.0",
+        "fs-extra": "^4.0.2",
+        "glob": "^7.1.2",
+        "joi": "^11.1.1",
+        "lodash.template": "^4.4.0",
+        "pretty-bytes": "^4.0.2",
+        "workbox-background-sync": "^3.4.1",
+        "workbox-broadcast-cache-update": "^3.4.1",
+        "workbox-cache-expiration": "^3.4.1",
+        "workbox-cacheable-response": "^3.4.1",
+        "workbox-core": "^3.4.1",
+        "workbox-google-analytics": "^3.4.1",
+        "workbox-navigation-preload": "^3.4.1",
+        "workbox-precaching": "^3.4.1",
+        "workbox-range-requests": "^3.4.1",
+        "workbox-routing": "^3.4.1",
+        "workbox-strategies": "^3.4.1",
+        "workbox-streams": "^3.4.1",
+        "workbox-sw": "^3.4.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/workbox-cache-expiration": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-cache-expiration/-/workbox-cache-expiration-3.5.0.tgz",
+      "integrity": "sha512-xorlgqgeGsQcZBjUuZ2LVongDZi9MeSOcMTFGGBZiXVKAgRJ7iG34rP3uSdMGKXc9hMF+5g/p0LtxDwenr3tYQ==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-cacheable-response": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-3.5.0.tgz",
+      "integrity": "sha512-/R833mjllyV5hveG0w9JmW7mr5/jKWqk6Z9qZbWHoZGxoZfi9SZWqyf0ehJocQlBpOHWV1ynDCeUmkR8AABv8A==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-core": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-3.5.0.tgz",
+      "integrity": "sha512-wZD4iM+Od3ssJLV1JCs7Dl2CswfTAaIhOBlV9WEASqYF9wKUHvJCnF0Cf6vVRaRuV2kaWXH7VB2Yh82eLkjyhQ==",
+      "dev": true
+    },
+    "node_modules/workbox-google-analytics": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-3.5.0.tgz",
+      "integrity": "sha512-eUOgTZkxYegpY16RUGt/J0cP0Zo8VIMyoUJh+StyNp3axpHEULpJPnB+xXH2aAQ1RMI/YVDM5u0az24kjYTfzQ==",
+      "dev": true,
+      "dependencies": {
+        "workbox-background-sync": "^3.5.0",
+        "workbox-core": "^3.5.0",
+        "workbox-routing": "^3.5.0",
+        "workbox-strategies": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-navigation-preload": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-3.5.0.tgz",
+      "integrity": "sha512-5jyd91B9niH7bkNjdwlwK8dgul2tdwtZc5i6UtECZPqakrnfBwm1+3wuaehs2SFxhD5xaYSL7w3B4SMzsP/Tqg==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-precaching": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-3.5.0.tgz",
+      "integrity": "sha512-6fLq14nZtWs3u7C+lzmRUuthJTQc+L4p20tDoW6EtizfiAr8MsY3nYsuuxf2cu4aDU0N7bAe8J7ajnN/cBSF4Q==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-range-requests": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-3.5.0.tgz",
+      "integrity": "sha512-kYvMTrzMJ4KMwDC1UUgzxU43KmFBnUrB0dVVl3Hro5sPqAOtu2d1xbotypXSgOKKOV41C+SSZQ3X0Hzt5z4B+A==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-routing": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-3.5.0.tgz",
+      "integrity": "sha512-L5oSFdyBVhGfZ+4c0hA/z7wmtODmjzlXImYSf17/SFOpk4MhDUNSnDl13P2IfhDrUqB+IHPlqTFYKuWU0AhqZQ==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-strategies": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-3.5.0.tgz",
+      "integrity": "sha512-3JS96V0jZTNjhOp9tMJwqd0h60K/Sf/LhUUNj8HNT+8Qx61tsP1Ya/1iBFPpeBpJ9qpbnGGeTrXNcOGscn6PNg==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-streams": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-3.5.0.tgz",
+      "integrity": "sha512-AbQASO9hR7O9pFd7zXThLb1T1pPu2ePfMb+hlo+NPcEdiYwUyDTMUHh93umnyE2/9uMT48GNah5ljaA0nGIFqw==",
+      "dev": true,
+      "dependencies": {
+        "workbox-core": "^3.5.0"
+      }
+    },
+    "node_modules/workbox-sw": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-3.5.0.tgz",
+      "integrity": "sha512-ejFm0EF2yuWAY9qJ4BNRrw3TNheqMGqGiLjZkz3WoWDTR8JAr/1WkfXh+uovG1b7J2UXeMURt3Yng419GK6ttw==",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@stencil-community/router": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stencil-community/router/-/router-1.0.2.tgz",
+      "integrity": "sha512-GQkhcwDZdkX6k6rE/ZqrH2mbxGt9wPq0KGAdwPJOcZJbfq9cKaSMOuS7heDEBcWgXgxJS2rKqwUKyKTj41g9pA==",
+      "requires": {
+        "@stencil/state-tunnel": "^1.0.1"
+      }
+    },
+    "@stencil/state-tunnel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stencil/state-tunnel/-/state-tunnel-1.0.1.tgz",
+      "integrity": "sha512-DYG8uROgL9hkjVTCtCfRBb0d3FwpiFB0muRrNZQ2X1Qo5hxMuNNji76/ILddqeq0AfgkKCW82xrMPDpy+rNIhQ=="
     },
     "babel-runtime": {
       "version": "6.26.0",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -10,7 +10,7 @@
     "test.watch": "jest --watch"
   },
   "dependencies": {
-    "@stencil/router": "^0.2.7-1"
+    "@stencil-community/router": "^1.0.2"
   },
   "jest": {
     "transform": {

--- a/packages/demo/src/components.d.ts
+++ b/packages/demo/src/components.d.ts
@@ -6,13 +6,13 @@
 
 import '@stencil/core';
 
-import '@stencil/router';
+import '@stencil-community/router';
 import '@stencil/state-tunnel';
 import {
   LocationSegments,
   MatchResults,
   RouterHistory,
-} from '@stencil/router';
+} from '@stencil-community/router';
 
 
 export namespace Components {

--- a/packages/demo/src/components/test-deep-component.tsx
+++ b/packages/demo/src/components/test-deep-component.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Prop } from '@stencil/core';
-import { RouterHistory, LocationSegments, injectHistory } from '@stencil/router';
+import { RouterHistory, LocationSegments, injectHistory } from '@stencil-community/router';
 
 @Component({
   tag: 'test-deep-component'

--- a/packages/demo/src/components/test-demo-four.tsx
+++ b/packages/demo/src/components/test-demo-four.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop } from '@stencil/core';
-import { RouterHistory, MatchResults } from '@stencil/router';
+import { RouterHistory, MatchResults } from '@stencil-community/router';
 
 @Component({
   tag: 'test-demo-four'

--- a/packages/demo/src/components/test-demo-seven.tsx
+++ b/packages/demo/src/components/test-demo-seven.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop } from '@stencil/core';
-import { RouterHistory, MatchResults } from '@stencil/router';
+import { RouterHistory, MatchResults } from '@stencil-community/router';
 
 @Component({
   tag: 'test-demo-seven'

--- a/packages/demo/src/components/test-demo-six.tsx
+++ b/packages/demo/src/components/test-demo-six.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop } from '@stencil/core';
-import { RouterHistory, MatchResults } from '@stencil/router';
+import { RouterHistory, MatchResults } from '@stencil-community/router';
 
 @Component({
   tag: 'test-demo-six'

--- a/packages/demo/src/components/test-demo-three.tsx
+++ b/packages/demo/src/components/test-demo-three.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop } from '@stencil/core';
-import { RouterHistory, MatchResults } from '@stencil/router';
+import { RouterHistory, MatchResults } from '@stencil-community/router';
 
 @Component({
   tag: 'test-demo-three'

--- a/packages/demo/src/components/test-route-guard.tsx
+++ b/packages/demo/src/components/test-route-guard.tsx
@@ -1,5 +1,5 @@
 import { Component, ComponentInterface, Prop, State } from '@stencil/core';
-import { RouterHistory, MatchResults } from '@stencil/router';
+import { RouterHistory, MatchResults } from '@stencil-community/router';
 
 @Component({
   tag: 'test-route-guard'


### PR DESCRIPTION
this commit updates the demo in this repository to use the
`@stencil-community` scoped version of the router. functionally, there
are no changes, as we move from using the same router published under a
different scope

this pr depends on #134. to land this pr, I plan on:

1. move this repository over to the new stencil community org in github
2. get #134 approved/landed
3. publish the package to the newly created `@stencil-community` npm org
4. get this approved and landed

**Testing**

Currently, the Stencil Router **does not work with Stencil v2**. This PR is mostly to move
the demo over to use the community version of the router. The demo itself is still in
a broken state