### PR TITLE
chore(types): specify @types/node version

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -27,6 +27,7 @@
     "@stencil/state-tunnel": "^1.0.1"
   },
   "devDependencies": {
+    "@types/node": "12.0.0",
     "np": "^5.0.3"
   },
   "author": "Ionic Team",


### PR DESCRIPTION
this commit add @types/node to the dependencies manifest for the router.
when trying to build this package without an earlier version of these
types, compilation fails. the compilation fails due to @types/node being
hoisted from the np package, and the types being hoisted are
incompatible with the version of typescript that is used with v1 of
stencil

without this, we're unable to successfully build the project