### PR TITLE
chore(readme): mark project as moved to stencil community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,11 @@
 [![npm][npm-badge]][npm-badge-url]
 ## Stencil Router
 
-## ☎️ Call for Maintainers ☎️
+⚠️ 📦 This project has moved to the Stencil Community 📦 ⚠️
 
-In the past, we’ve created packages under the Stencil name to keep them out of the core compiler. Looking to this year and beyond, we’re going to focus on Stencil as a compiler for web components and begin to move away from creating full-blown web applications using packages maintained by Ionic.
+This project has been moved to the Stencil Community. Going forward, it will be maintained by members of the Stencil community, rather than Ionic. Please see the [new repository](https://github.com/stencil-community/stencil-router) for updates to this project going forward.
 
-We're excited to share that we have a [Stencil community org on GitHub](https://github.com/stencil-community). This will be a central place for projects driven by our community of Stencil developers.
-
-We recognize and appreciate that folks may want to continue building applications with Stencil. With this Stencil community organization, we’re going to be moving this package to the community org so that folks who want to continue to develop applications in Stencil can do so and take a more active role in its development
-
-We’re looking for community members to take ownership of this project. **If you are interested in becoming a maintainer, feel free to send Anthony Giuliano a direct message in the [Stencil Slack](https://stencil-worldwide.slack.com/archives/D03EU2YMN0P) or on Twitter ([@a__giuliano](https://twitter.com/a__giuliano))**. Even if you are unsure about becoming a maintainer, please feel free to reach out. We’re more than happy to discuss what this would look like. We’re really excited about giving the Stencil community greater ownership and all the amazing projects that we know will come from it.
+This repository has been kept in readonly/archive mode for historical purposes.
 
 ---
 


### PR DESCRIPTION
designate that the project has been moved to the stencil community
prior to archiving it (thus making it read only)