### PR TITLE
chore(urls): update urls to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A simple router, inspired by React Router v4, for Stencil apps and vanilla Web C
 
 Included components and all other information can be found in our [wiki].
 
-[wiki]: https://github.com/ionic-team/stencil-router/wiki
+[wiki]: https://github.com/stencil-community/stencil-router/wiki
 
 [npm-badge]: https://img.shields.io/npm/v/@stencil-community/router.svg
 [npm-badge-url]: https://www.npmjs.com/package/@stencil-community/router

--- a/packages/demo/readme.md
+++ b/packages/demo/readme.md
@@ -13,7 +13,7 @@ Stencil also enables a number of key capabilities on top of Web Components, in p
 To start a new project using Stencil, clone this repo to a new directory:
 
 ```bash
-git clone https://github.com/ionic-team/stencil-starter.git my-app
+git clone https://github.com/stencil-community/stencil-app-starter.git my-app
 cd my-app
 git remote rm origin
 ```

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -33,7 +33,7 @@
   "author": "Ionic Team",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/stencil-community/stencil-router"
+    "url": "https://github.com/stencil-community/stencil-router/issues"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ionic-team/stencil-router.git"
+    "url": "git+https://github.com/stencil-community/stencil-router.git"
   },
   "dependencies": {
     "@stencil/state-tunnel": "^1.0.1"
@@ -33,7 +33,7 @@
   "author": "Ionic Team",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ionic-team/stencil-router"
+    "url": "https://github.com/stencil-community/stencil-router"
   },
   "jest": {
     "moduleFileExtensions": [
@@ -46,5 +46,5 @@
     },
     "testRegex": "/__tests__/.*(test|spec)\\.(ts|tsx)$"
   },
-  "homepage": "https://github.com/ionic-team/stencil-router"
+  "homepage": "https://github.com/stencil-community/stencil-router"
 }


### PR DESCRIPTION
this commit updates various urls to point to the stencil-community
rather than the ionic-team organization. although github will
automatically forward requests to the new org, there are some places
like npm where that forwarding is less obvious