### PR TITLE
Update README & adjust package names for community package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Functional Components are the used to collect the list of routes, finally the `S
 ## Install
 
 ```bash
-npm install @stencil-community/router
+npm install @stencil-community/router --save-dev
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Functional Components are the used to collect the list of routes, finally the `S
 ## Install
 
 ```bash
-npm install stencil-router-v2 --save-dev
+npm install @stencil-community/router
 ```
 
 ## Examples
 
 ```tsx
-import { createRouter, Route } from 'stencil-router-v2';
+import { createRouter, Route } from '@stencil-community/router';
 
 const Router = createRouter();
 
@@ -75,7 +75,7 @@ Regex or functional matches have the chance to generate an object of params when
 
 
 ```tsx
-import { createRouter, Route, match } from 'stencil-router-v2';
+import { createRouter, Route, match } from '@stencil-community/router';
 
 const Router = createRouter();
 
@@ -116,7 +116,7 @@ A simple router, inspired by React Router v4, for Stencil apps and vanilla Web C
 The `href()` function will inject all the handles to an native `anchor`, without extra DOM.
 
 ```tsx
-import { createRouter, Route, href } from 'stencil-router-v2';
+import { createRouter, Route, href } from '@stencil-community/router';
 
 const Router = createRouter();
 
@@ -172,7 +172,7 @@ export class AppRoot {
 Because the router uses `@stencil/store` its trivial to subscribe to changes in the locations, activeRoute, or even the list of routes.
 
 ```tsx
-import { createRouter, Route } from 'stencil-router-v2';
+import { createRouter, Route } from '@stencil-community/router';
 
 const Router = createRouter();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14953,8 +14953,15 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@stencil-community/router": "^2.0.0-2"
+        "@stencil-community/router": "stencil-community/stencil-router"
       }
+    },
+    "packages/demo/node_modules/@stencil-community/router": {
+      "name": "root",
+      "resolved": "git+ssh://git@github.com/stencil-community/stencil-router.git#cf47ca8e3a2e4ea4b68ec58ec5cdfaf121bb7f36",
+      "workspaces": [
+        "packages/*"
+      ]
     },
     "packages/router": {
       "name": "@stencil-community/router",
@@ -19166,7 +19173,13 @@
     "demo": {
       "version": "file:packages/demo",
       "requires": {
-        "@stencil-community/router": "^2.0.0-2"
+        "@stencil-community/router": "stencil-community/stencil-router"
+      },
+      "dependencies": {
+        "@stencil-community/router": {
+          "version": "git+ssh://git@github.com/stencil-community/stencil-router.git#cf47ca8e3a2e4ea4b68ec58ec5cdfaf121bb7f36",
+          "from": "@stencil-community/router@stencil-community/stencil-router"
+        }
       }
     },
     "depd": {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "root",
   "private": true,
   "devDependencies": {
-    "lerna": "^5.4.2",
-    "@stencil/core": "^2.17.3"
+    "@stencil/core": "^2.17.3",
+    "lerna": "^5.4.2"
   },
   "workspaces": [
     "packages/*"

--- a/packages/demo/package-lock.json
+++ b/packages/demo/package-lock.json
@@ -1,21 +1,29 @@
 {
-  "name": "stencil-store-tests",
+  "name": "demo",
   "version": "0.0.1",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@stencil/store": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@stencil/store/-/store-1.3.0.tgz",
-      "integrity": "sha512-e1/Ru/q8P5BkqUYMF+kW54rFWyH9XRABLcxFLruUlbw+ZIGN5OwKe6Rf1vw1wQSa/6vMy0EQq5IrkRYNhENpOA=="
-    },
-    "stencil-router-v2": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/stencil-router-v2/-/stencil-router-v2-0.5.0.tgz",
-      "integrity": "sha512-pIciksEZ9m6yps6QMnLYdDDvuiPNKACh8gksUtitvBaoBJxyQT48IXJ02ZwMwB7gjiD3u7A50iosCdJqHJfgTQ==",
-      "requires": {
-        "@stencil/store": "^1.1.0"
+  "packages": {
+    "": {
+      "name": "demo",
+      "version": "0.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "@stencil-community/router": "stencil-community/stencil-router"
       }
+    },
+    "node_modules/@stencil-community/router": {
+      "name": "root",
+      "resolved": "git+ssh://git@github.com/stencil-community/stencil-router.git#cf47ca8e3a2e4ea4b68ec58ec5cdfaf121bb7f36",
+      "workspaces": [
+        "packages/*"
+      ]
+    }
+  },
+  "dependencies": {
+    "@stencil-community/router": {
+      "version": "git+ssh://git@github.com/stencil-community/stencil-router.git#cf47ca8e3a2e4ea4b68ec58ec5cdfaf121bb7f36",
+      "from": "@stencil-community/router@stencil-community/stencil-router"
     }
   }
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -21,6 +21,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@stencil-community/router": "^2.0.0-2"
+    "@stencil-community/router": "stencil-community/stencil-router"
   }
 }

--- a/packages/demo/prerendering.config.ts
+++ b/packages/demo/prerendering.config.ts
@@ -1,5 +1,5 @@
 import { PrerenderConfig } from '@stencil/core';
-import { afterHydrate } from 'stencil-router-v2/static';
+import { afterHydrate } from '@stencil-community/router/static';
 
 export const config: PrerenderConfig = {
   async afterHydrate(doc, url, results) {

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -45,6 +45,7 @@
     "url": "git://github.com/ionic-team/stencil-router.git"
   },
   "homepage": "https://stenciljs.com/",
+  "bugs": "https://github.com/stencil-community/stencil-router/issues",
   "workspaces": [
     "packages/*"
   ]


### PR DESCRIPTION
A noticed a few things didn't get caught with the change to the community repo, so this updates them.

LMK if the change to install the package from GitHub for the demo is a bad idea. Since the 2.x.x series isn't on npm yet in the new package, the demo can't be installed and doesn't work.

I'm new to lerna too, so I may have messed something up there.

I'm happy to help further contribute to and maintain the router if any help is needed there.

Thanks!
