### PR TITLE
Updates package repository url

### DIFF
--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -42,7 +42,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/ionic-team/stencil-router.git"
+    "url": "git://github.com/stencil-community/stencil-router.git"
   },
   "homepage": "https://stenciljs.com/",
   "workspaces": [


### PR DESCRIPTION
This was pointed to Ionic and causing a redirect (so was still working) but on npm.js it was a bit of a source of confusion